### PR TITLE
Update query tag JSON

### DIFF
--- a/macros/query_tags.sql
+++ b/macros/query_tags.sql
@@ -30,7 +30,7 @@
     {% if model.resource_type == 'model' %}
 
         {# 
-           Lines XX - YY would have been a macro called `bruce_force_cluster_list`, but I kept
+           Lines 38 - 46 would have been a macro called `bruce_force_cluster_list`, but I kept
            getting a "'brute_force_cluster_list' is undefined" error, so I gave up and shoved
            the logic in here. The `cluster_by` config accepts a string or list, and this handles
            either conditions and "returns" it as a list to the JSON object.


### PR DESCRIPTION
This PR updates the `default__set_query_tag` macro in 2 ways:
* Reintroduces the `model_cluster_key` key-value pair. We account for the fact that the `cluster_by` config can be set with either a string or list and "return" a list to JSON object.
* Fixes an issue where `model_fqn` causes invalid JSON by removing the `tojson()` context method as dbt passes `model.fqn` as a list.

This query was tested in `dev16` and you can see it works using this query:
```
select parse_json(query_tag) as parsed_query_tag, parsed_query_tag:model_fqn as model_fqn, parsed_query_tag:model_cluster_key as cluster_key, * from snowflake.account_usage.query_history where start_time::date = '2023-10-09' and query_text like '%bfd4712c-c478-4629-a457-c6063c1717dc%' ;
```